### PR TITLE
feat: remove references to public ws server

### DIFF
--- a/autoblog-cli/CLAUDE.md
+++ b/autoblog-cli/CLAUDE.md
@@ -17,7 +17,7 @@ The project consists of two main components:
 1. Author writes markdown files locally with frontmatter metadata
 2. CLI tool parses markdown files and extracts frontmatter (title, author, publish date, etc.)
 3. Content is stored as Automerge documents with local NodeFS storage
-4. Documents sync to Automerge's public sync server (`wss://sync.automerge.org`)
+4. Documents sync to Automerge's public sync server to local sync server 
 5. Multiple clients can sync the same documents for collaborative editing
 
 ### Key Technologies

--- a/autoblog-cli/README.md
+++ b/autoblog-cli/README.md
@@ -8,7 +8,7 @@ A command-line interface for managing markdown files in the Automerge-powered bl
 
 Autoblog CLI allows authors to upload markdown files to a local-first blog system built on Automerge 2.0. It parses markdown files with frontmatter, creates Automerge documents, and syncs them across devices using CRDT technology.
 
-The CLI uses both local storage and the Automerge sync server at `wss://sync.automerge.org` for reliable local-first operation with cross-device synchronization. The CLI supports flexible configuration through config files, environment variables, and command-line options.
+The CLI uses both local storage and the local Automerge sync server for reliable local-first operation with cross-device synchronization. The CLI supports flexible configuration through config files, environment variables, and command-line options.
 
 ## Installation
 
@@ -75,14 +75,6 @@ Autoblog CLI supports flexible configuration through multiple methods with clear
 - **Linux**: `~/.local/share/autoblog/` (or `$XDG_DATA_HOME/autoblog/`)
 - **Windows**: `%APPDATA%/autoblog/data/`
 - **Project-specific**: `.autoblog/data/` (when using project config)
-
-### Environment Variables
-
-```bash
-AUTOBLOG_SYNC_URL=wss://sync.automerge.org
-AUTOBLOG_DATA_PATH=~/.local/share/autoblog
-AUTOBLOG_TIMEOUT=30000
-```
 
 ### Configuration Management Commands
 

--- a/autoblog-cli/src/lib/config.ts
+++ b/autoblog-cli/src/lib/config.ts
@@ -25,7 +25,7 @@ function getDefaultDataPath(): string {
 
 function getDefaultSyncServer(): string {
   // TODO: get from config file
-  return 'wss://sync.automerge.org';
+  return 'ws://10.10.1.122:3030';
 }
 
 export function getConfig(): SimpleConfig {

--- a/autoblog-cli/tests/unit/automerge.test.ts
+++ b/autoblog-cli/tests/unit/automerge.test.ts
@@ -32,7 +32,7 @@ vi.mock('../../src/lib/index.js', () => ({
 // Mock the config module
 vi.mock('../../src/lib/config.js', () => ({
   getConfig: vi.fn(() => ({
-    syncUrl: 'wss://sync.automerge.org',
+    syncUrl: 'wss://sync_server',
     dataPath: './test-data',
   })),
 }));
@@ -70,7 +70,7 @@ describe.skip('Automerge Module', () => {
     // Setup config mock
     vi.mocked(getConfig).mockReturnValue({
       dataPath: './autoblog-data',
-      syncUrl: 'wss://sync.automerge.org',
+      syncUrl: 'wss://sync_server',
     });
 
     // Setup basic mocks
@@ -85,7 +85,7 @@ describe.skip('Automerge Module', () => {
     vi.mocked(WebSocketClientAdapter).mockImplementation(
       () =>
         ({
-          url: 'wss://sync.automerge.org',
+          url: 'wss://sync_server',
           type: 'WebSocketClientAdapter',
         }) as any
     );
@@ -147,9 +147,7 @@ describe.skip('Automerge Module', () => {
       const repo = await initRepo();
 
       expect(NodeFSStorageAdapter).toHaveBeenCalledWith('./autoblog-data');
-      expect(WebSocketClientAdapter).toHaveBeenCalledWith(
-        'wss://sync.automerge.org'
-      );
+      expect(WebSocketClientAdapter).toHaveBeenCalledWith('wss://sync_server');
       expect(Repo).toHaveBeenCalledWith({
         storage: expect.objectContaining({
           path: './autoblog-data',
@@ -157,7 +155,7 @@ describe.skip('Automerge Module', () => {
         }),
         network: [
           expect.objectContaining({
-            url: 'wss://sync.automerge.org',
+            url: 'wss://sync_server',
             type: 'WebSocketClientAdapter',
           }),
         ],

--- a/autoblog-cli/tests/unit/index.test.ts
+++ b/autoblog-cli/tests/unit/index.test.ts
@@ -32,7 +32,7 @@ vi.mock('path', () => ({
 // Mock the config module
 vi.mock('../../src/lib/config.js', () => ({
   getConfig: vi.fn(() => ({
-    syncUrl: 'wss://sync.automerge.org',
+    syncUrl: 'wss://sync_server',
     dataPath: './test-data',
   })),
 }));
@@ -65,7 +65,7 @@ describe('Index Module', () => {
     // Setup config mock
     vi.mocked(getConfig).mockReturnValue({
       dataPath: './autoblog-data',
-      syncUrl: 'wss://sync.automerge.org',
+      syncUrl: 'wss://sync_server',
     });
 
     // Setup path mocks

--- a/autoblog-web/.env.example
+++ b/autoblog-web/.env.example
@@ -1,5 +1,5 @@
 # WebSocket sync server URL
-AUTOBLOG_SYNC_URL=wss://sync.automerge.org
+AUTOBLOG_SYNC_URL=wss://10.10.1.122:3030
 
 # Browser database name
 AUTOBLOG_DB_NAME=autoblog-web

--- a/autoblog-web/README.md
+++ b/autoblog-web/README.md
@@ -99,7 +99,7 @@ Create a `.env.local` file for local development:
 
 ```env
 # Automerge sync server URL (optional - defaults to public server)
-VITE_SYNC_URL=wss://sync.automerge.org
+VITE_SYNC_URL=wss://sync_server
 ```
 
 ### Build Configuration

--- a/autoblog-web/src/config/runtime.ts
+++ b/autoblog-web/src/config/runtime.ts
@@ -13,16 +13,14 @@ export const getRuntimeConfig = () => {
   if (import.meta.env.DEV) {
     // Development mode - using env vars
     return {
-      syncUrl:
-        import.meta.env.VITE_AUTOBLOG_SYNC_URL || 'wss://sync.automerge.org',
+      syncUrl: import.meta.env.VITE_AUTOBLOG_SYNC_URL,
       indexId: import.meta.env.VITE_AUTOBLOG_INDEX_ID || '',
     }
   }
 
   // In production, use window._env_ (injected by Docker)
   return {
-    syncUrl:
-      window._env_?.REACT_AUTOBLOG_SYNC_URL || 'wss://sync.automerge.org',
+    syncUrl: window._env_?.REACT_AUTOBLOG_SYNC_URL,
     indexId: window._env_?.REACT_AUTOBLOG_INDEX_ID || '',
   }
 }

--- a/autoblog-web/src/contexts/AutomergeContext.tsx
+++ b/autoblog-web/src/contexts/AutomergeContext.tsx
@@ -14,7 +14,7 @@ interface AutomergeProviderProps {
 }
 
 const DEFAULT_CONFIG: AppConfig = {
-  syncUrl: 'wss://sync.automerge.org',
+  syncUrl: 'wss://sync_server',
   theme: 'system',
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,25 @@
 version: '3.8'
 
 services:
+  # sync-server:
+  #   image: ghcr.io/automerge/automerge-repo-sync-server:main
+  #   container_name: autoblog-sync-server
+  #   ports:
+  #     - "3030:3030"
+  #   restart: unless-stopped
+  #   networks:
+  #     - autoblog-network
+
   autoblog-web:
-    image: evcraddock/autoblog-web:1.0.3
+    image: evcraddock/autoblog-web:1.0.4
     container_name: autoblog-web
     ports:
       - "8085:80"
     environment:
-      - AUTOBLOG_SYNC_URL=${AUTOBLOG_SYNC_URL:-wss://sync.automerge.org}
-      - AUTOBLOG_INDEX_ID=${AUTOBLOG_INDEX_ID}
+      - REACT_AUTOBLOG_SYNC_URL=${AUTOBLOG_SYNC_URL}
+      - REACT_AUTOBLOG_INDEX_ID=${AUTOBLOG_INDEX_ID}
+    # depends_on:
+    #   - sync-server
     restart: unless-stopped
     networks:
       - autoblog-network

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -93,7 +93,7 @@ import { WebSocketClientAdapter } from "@automerge/automerge-repo-network-websoc
 
 export function initRepo() {
   const storage = new NodeFSStorageAdapter("./autoblog-data")
-  const network = [new WebSocketClientAdapter("ws://localhost:3030")] // Or wss://sync.automerge.org
+  const network = [new WebSocketClientAdapter("ws://localhost:3030")] // Or wss://sync_server
   
   return new Repo({ 
     storage,
@@ -259,9 +259,9 @@ Simple hash-based routing for MVP:
 ### Sync Server Options
 
 #### Option 1: Automerge Sync Server (Recommended for MVP)
-- Use the public sync server at `wss://sync.automerge.org`
+- Use the public sync server at `wss://sync_server`
 - No setup required
-- Replace `ws://localhost:3030` with `wss://sync.automerge.org` in both apps
+- Replace `ws://localhost:3030` with `wss://sync_server` in both apps
 
 #### Option 2: Self-Hosted Sync Server
 ```bash

--- a/docs/archived/brainstorm.md
+++ b/docs/archived/brainstorm.md
@@ -26,7 +26,7 @@ Based on the Automerge documentation, here are the available adapters:
 
 **Network Adapters for syncing:**
 - **BroadcastChannelNetworkAdapter** - Syncs between browser tabs locally
-- **WebSocketClientAdapter** - Syncs across devices via a server (e.g., wss://sync.automerge.org)
+- **WebSocketClientAdapter** - Syncs across devices via a server (e.g., wss://sync_server)
 
 Given these options, which approach appeals to you for your blog?
 1. Pure local with IndexedDB (browser-only, no syncing between devices)

--- a/docs/archived/mvp-cli-context.md
+++ b/docs/archived/mvp-cli-context.md
@@ -208,7 +208,7 @@ Create src/lib/automerge.ts that:
 2. Imports NodeFSStorageAdapter and WebSocketClientAdapter
 3. Creates an initRepo() function that:
    - Creates a storage adapter pointing to "./autoblog-data"
-   - Creates a network adapter connecting to "wss://sync.automerge.org"
+   - Creates a network adapter connecting to "wss://sync_server"
    - Returns a new Repo instance with both adapters
 4. Exports the initRepo function
 

--- a/docs/archived/phase-1-cli-features.md
+++ b/docs/archived/phase-1-cli-features.md
@@ -158,7 +158,7 @@ export interface BlogIndex {
 #### Current Sync Configuration
 ```typescript
 // From lib/automerge.ts
-const network = [new WebSocketClientAdapter("wss://sync.automerge.org")]
+const network = [new WebSocketClientAdapter("wss://sync_server")]
 ```
 
 #### Implementation Requirements

--- a/docs/features/cli-configuration-management.md
+++ b/docs/features/cli-configuration-management.md
@@ -53,7 +53,7 @@ The complete configuration schema with default values:
 ```json
 {
   "network": {
-    "syncUrl": "wss://sync.automerge.org",
+    "syncUrl": "wss://sync_server",
     "timeout": 30000
   },
   "storage": {
@@ -68,7 +68,7 @@ The complete configuration schema with default values:
 #### Network Configuration
 
 - **`syncUrl`** (string): WebSocket URL for Automerge CRDT synchronization
-  - Default: `"wss://sync.automerge.org"`
+  - Default: `"wss://sync_server"`
   - Purpose: Remote synchronization server endpoint
 
 - **`timeout`** (number): Network timeout in milliseconds

--- a/docs/features/cli-list-command.md
+++ b/docs/features/cli-list-command.md
@@ -31,7 +31,7 @@ The list command displays all blog posts in the Autoblog system in a formatted t
 #### Command Options
 - `--source <source>`: Choose sync source (default: 'remote')
   - `local`: Read from local file system only
-  - `remote`: Sync with Automerge server at `wss://sync.automerge.org`
+  - `remote`: Sync with Automerge server at `wss://sync_server`
 
 #### Table Columns
 1. **Title** (30 chars): Post title with word wrap

--- a/docs/features/cli-sync-source-support.md
+++ b/docs/features/cli-sync-source-support.md
@@ -9,7 +9,7 @@
 The sync source support system that allowed users to choose between 'local', 'remote', or 'all' synchronization modes has been simplified. The CLI now:
 
 - **Always uses NodeFSStorageAdapter** for local filesystem storage
-- **Always uses WebSocketClientAdapter** for remote synchronization to `wss://sync.automerge.org`
+- **Always uses WebSocketClientAdapter** for remote synchronization to `wss://sync_server`
 - **Removed the `--source` CLI option** from all commands
 - **Removed the `sync.defaultSource` configuration** option
 

--- a/docs/features/cli-upload-command.md
+++ b/docs/features/cli-upload-command.md
@@ -35,7 +35,7 @@ The upload command allows authors to upload markdown files with frontmatter meta
 #### Command Options
 - `--source <source>`: Choose sync source (default: 'remote')
   - `local`: Store only in local file system
-  - `remote`: Sync with Automerge server at `wss://sync.automerge.org`
+  - `remote`: Sync with Automerge server at `wss://sync_server`
 
 #### Required Frontmatter Fields
 - `title`: The blog post title (required)

--- a/docs/features/cli-web-sync-integration.md
+++ b/docs/features/cli-web-sync-integration.md
@@ -9,7 +9,7 @@ This document describes the integration between the Autoblog CLI and Web applica
 The CLI and Web applications were using different index documents, preventing them from sharing blog posts:
 - CLI stored an index document ID in `autoblog-cli/autoblog-data/index-id.txt`
 - Web app created its own index document and stored the ID in browser localStorage
-- Both apps connected to the same sync server (`wss://sync.automerge.org`) but couldn't see each other's posts
+- Both apps connected to the same sync server (`wss://sync_server`) but couldn't see each other's posts
 
 ## Solution Implementation
 
@@ -78,7 +78,7 @@ export function HomePage() {
 #### Storage Architecture
 - **CLI**: Uses `NodeFSStorageAdapter('./autoblog-data')` for filesystem storage
 - **Web**: Uses `IndexedDBStorageAdapter('autoblog-web')` for browser storage
-- Both sync through the same WebSocket server at `wss://sync.automerge.org`
+- Both sync through the same WebSocket server at `wss://sync_server`
 
 #### Sync Behavior
 - CLI: Always uses both local filesystem storage and WebSocket sync

--- a/docs/features/runtime-environment-variables.md
+++ b/docs/features/runtime-environment-variables.md
@@ -81,14 +81,14 @@ export const getRuntimeConfig = () => {
   // In development, use import.meta.env
   if (import.meta.env.DEV) {
     return {
-      syncUrl: import.meta.env.VITE_AUTOBLOG_SYNC_URL || 'wss://sync.automerge.org',
+      syncUrl: import.meta.env.VITE_AUTOBLOG_SYNC_URL || 'wss://sync_server',
       indexId: import.meta.env.VITE_AUTOBLOG_INDEX_ID || '',
     };
   }
   
   // In production, use window._env_ (injected by Docker)
   return {
-    syncUrl: window._env_?.REACT_AUTOBLOG_SYNC_URL || 'wss://sync.automerge.org',
+    syncUrl: window._env_?.REACT_AUTOBLOG_SYNC_URL || 'wss://sync_server',
     indexId: window._env_?.REACT_AUTOBLOG_INDEX_ID || '',
   };
 };
@@ -122,7 +122,7 @@ services:
   autoblog-web:
     image: evcraddock/autoblog-web:latest
     environment:
-      - AUTOBLOG_SYNC_URL=wss://sync.automerge.org
+      - AUTOBLOG_SYNC_URL=wss://sync_server
       - AUTOBLOG_INDEX_ID=your-index-id
     ports:
       - "8085:80"
@@ -132,7 +132,7 @@ services:
 
 ```bash
 docker run -d \
-  -e AUTOBLOG_SYNC_URL=wss://sync.automerge.org \
+  -e AUTOBLOG_SYNC_URL=wss://sync_server \
   -e AUTOBLOG_INDEX_ID=your-index-id \
   -p 8085:80 \
   evcraddock/autoblog-web:latest
@@ -153,7 +153,7 @@ spec:
         image: evcraddock/autoblog-web:latest
         env:
         - name: AUTOBLOG_SYNC_URL
-          value: "wss://sync.automerge.org"
+          value: "wss://sync_server"
         - name: AUTOBLOG_INDEX_ID
           valueFrom:
             secretKeyRef:

--- a/docs/features/web-viewer-configuration-management.md
+++ b/docs/features/web-viewer-configuration-management.md
@@ -12,7 +12,7 @@ The following values need to be configurable:
 
 ```bash
 # WebSocket sync server URL
-AUTOBLOG_SYNC_URL=wss://sync.automerge.org
+AUTOBLOG_SYNC_URL=wss://sync_server
 
 # Browser database name
 AUTOBLOG_DB_NAME=autoblog-web
@@ -30,7 +30,7 @@ Create a simple configuration service that reads from environment variables:
 ```typescript
 // src/config/index.ts
 export const config = {
-  syncUrl: import.meta.env.AUTOBLOG_SYNC_URL || 'wss://sync.automerge.org',
+  syncUrl: import.meta.env.AUTOBLOG_SYNC_URL || 'wss://sync_server',
   databaseName: import.meta.env.AUTOBLOG_DB_NAME || 'autoblog-web',
   // Optional: Specific index ID to use (for CLI integration)
   indexId: import.meta.env.AUTOBLOG_INDEX_ID || undefined,
@@ -43,7 +43,7 @@ Replace hardcoded values with config references:
 
 ```typescript
 // Before
-const syncUrl = 'wss://sync.automerge.org'
+const syncUrl = 'wss://sync_server'
 
 // After
 import { config } from '@/config'
@@ -57,7 +57,7 @@ services:
   autoblog-web:
     image: autoblog-web:latest
     environment:
-      - AUTOBLOG_SYNC_URL=wss://sync.automerge.org
+      - AUTOBLOG_SYNC_URL=wss://sync_server
       - AUTOBLOG_DB_NAME=autoblog-web
       - AUTOBLOG_INDEX_ID=your-index-id
     ports:
@@ -69,7 +69,7 @@ services:
 For Vite-based builds, create a `.env` file:
 
 ```bash
-AUTOBLOG_SYNC_URL=wss://sync.automerge.org
+AUTOBLOG_SYNC_URL=wss://sync_server
 AUTOBLOG_DB_NAME=autoblog-web
 AUTOBLOG_INDEX_ID=your-index-id
 ```

--- a/hack/set-autoblog-env.sh
+++ b/hack/set-autoblog-env.sh
@@ -8,10 +8,10 @@ echo "Setting autoblog environment for configuration: $CONFIG"
 if [ "$CONFIG" = "local" ]; then
     # Use local development configuration
     echo "Using local development configuration..."
-    SYNC_URL="http://localhost:3030"
+    SYNC_URL="ws://localhost:3030"
 else
     # Set default sync URL
-    SYNC_URL="wss://sync.automerge.org"
+    SYNC_URL="ws://10.10.1.122:3030"
 fi    
 
 # Set default data path using cross-platform method

--- a/hack/start-docker-website.sh
+++ b/hack/start-docker-website.sh
@@ -15,7 +15,7 @@ echo ""
 
 # Start docker-compose
 cd "$PROJECT_ROOT"
-docker-compose up -d
+docker compose up -d
 
 echo ""
 echo "Autoblog website started in Docker container"


### PR DESCRIPTION
## Summary
- Replace all references to wss://sync.automerge.org with local sync server references
- Update default sync URL to use local server (ws://10.10.1.122:3030)
- Clean up documentation to reflect local-first architecture

## Test plan
- [x] All unit tests pass for both autoblog-web and autoblog-cli
- [ ] Local sync server connects properly
- [ ] Web app connects to local sync server
- [ ] CLI connects to local sync server

🤖 Generated with [Claude Code](https://claude.ai/code)