### PR TITLE
fix: standardize environment variable names and remove REACT_ prefix

### DIFF
--- a/autoblog-web/env.sh
+++ b/autoblog-web/env.sh
@@ -9,7 +9,7 @@ echo "window._env_ = {" >> /usr/share/nginx/html/env-config.js
 
 # Read each line in .env file or use environment variables
 # Each line represents key=value pairs
-echo "  REACT_AUTOBLOG_SYNC_URL: \"${AUTOBLOG_SYNC_URL}\"," >> /usr/share/nginx/html/env-config.js
-echo "  REACT_AUTOBLOG_INDEX_ID: \"${AUTOBLOG_INDEX_ID}\"" >> /usr/share/nginx/html/env-config.js
+echo "  AUTOBLOG_SYNC_URL: \"${AUTOBLOG_SYNC_URL}\"," >> /usr/share/nginx/html/env-config.js
+echo "  AUTOBLOG_INDEX_ID: \"${AUTOBLOG_INDEX_ID}\"" >> /usr/share/nginx/html/env-config.js
 
 echo "}" >> /usr/share/nginx/html/env-config.js

--- a/autoblog-web/src/config/runtime.ts
+++ b/autoblog-web/src/config/runtime.ts
@@ -2,8 +2,8 @@
 declare global {
   interface Window {
     _env_?: {
-      REACT_AUTOBLOG_SYNC_URL?: string
-      REACT_AUTOBLOG_INDEX_ID?: string
+      AUTOBLOG_SYNC_URL?: string
+      AUTOBLOG_INDEX_ID?: string
     }
   }
 }
@@ -20,7 +20,7 @@ export const getRuntimeConfig = () => {
 
   // In production, use window._env_ (injected by Docker)
   return {
-    syncUrl: window._env_?.REACT_AUTOBLOG_SYNC_URL,
-    indexId: window._env_?.REACT_AUTOBLOG_INDEX_ID || '',
+    syncUrl: window._env_?.AUTOBLOG_SYNC_URL,
+    indexId: window._env_?.AUTOBLOG_INDEX_ID || '',
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,13 +11,13 @@ services:
   #     - autoblog-network
 
   autoblog-web:
-    image: evcraddock/autoblog-web:1.0.4
+    image: evcraddock/autoblog-web:1.0.6
     container_name: autoblog-web
     ports:
       - "8085:80"
     environment:
-      - REACT_AUTOBLOG_SYNC_URL=${AUTOBLOG_SYNC_URL}
-      - REACT_AUTOBLOG_INDEX_ID=${AUTOBLOG_INDEX_ID}
+      - AUTOBLOG_SYNC_URL=${AUTOBLOG_SYNC_URL}
+      - AUTOBLOG_INDEX_ID=${AUTOBLOG_INDEX_ID}
     # depends_on:
     #   - sync-server
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- Remove REACT_ prefix from all environment variables for consistency
- Standardize on simple AUTOBLOG_SYNC_URL and AUTOBLOG_INDEX_ID throughout the codebase
- Update runtime configuration to use consistent variable names
- Update Docker configuration for v1.0.6 with simplified environment variables

## Changes Made
- **runtime.ts**: Updated to read AUTOBLOG_* instead of REACT_AUTOBLOG_* from window._env_
- **env.sh**: Updated to write AUTOBLOG_* variables to window._env_ object
- **docker-compose.yml**: Updated to use v1.0.6 image and pass AUTOBLOG_* variables directly

## Test Plan
- [x] All unit tests pass (39/39)
- [x] Build completes successfully
- [ ] Docker image needs to be built with v1.0.6 tag for full functionality
- [ ] Environment variables should display correctly on homepage after deployment

🤖 Generated with [Claude Code](https://claude.ai/code)